### PR TITLE
[FEATURE] Add Hugo page view buttons into page context-sensitive menu

### DIFF
--- a/Classes/ContextMenu/ItemProviders/PageView.php
+++ b/Classes/ContextMenu/ItemProviders/PageView.php
@@ -1,0 +1,133 @@
+<?php
+namespace SourceBroker\Hugo\ContextMenu\ItemProviders;
+
+use SourceBroker\Hugo\Utility\DomainUtility;
+use SourceBroker\Hugo\Utility\RootlineUtility;
+use TYPO3\CMS\Backend\ContextMenu\ItemProviders\AbstractProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Lang\LanguageService;
+
+/**
+ * Item provider adding Hello World item
+ */
+class PageView extends AbstractProvider
+{
+    /**
+     * @var array
+     */
+    protected $itemsConfiguration = [];
+
+    /**
+     * @var array
+     */
+    protected $hugoViewItemBaseConfiguration = [
+        'type' => 'item',
+        'label' => 'LLL:EXT:hugo/Resources/Private/Language/locallang_db.xlf:context_menu.pageView.label',
+        'iconIdentifier' => 'actions-document-view',
+        'callbackAction' => 'viewPage'
+    ];
+
+    /**
+     * @return bool
+     */
+    public function canHandle(): bool
+    {
+        return $this->table === 'pages';
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return 77;
+    }
+
+    /**
+     * @param array $items
+     * @return array
+     */
+    public function addItems(array $items): array
+    {
+        if (!array_key_exists('view', $items)) {
+            return $items;
+        }
+
+        $this->setHugoViewItemsConfiguration();
+
+        $localItems = $this->prepareItems($this->itemsConfiguration);
+        $position = array_search('view', array_keys($items), true);
+        $beginning = array_slice($items, 0, $position + 1, true);
+        $end = array_slice($items, $position, null, true);
+
+        return $beginning + $localItems + $end;
+    }
+
+    /**
+     * @param string $itemName
+     * @param string $type
+     * @return bool
+     */
+    protected function canRender(string $itemName, string $type): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param string $itemName
+     *
+     * @return array
+     */
+    protected function getAdditionalAttributes(string $itemName): array
+    {
+        if (!isset($this->itemsConfiguration[$itemName])) {
+            return [];
+        }
+
+        $itemConfiguration = $this->itemsConfiguration[$itemName];
+
+        if (empty($itemConfiguration['txHugoDomain']) || empty($itemConfiguration['txHugoPageUid'])) {
+            return [];
+        }
+
+        $rootLineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $itemConfiguration['txHugoPageUid']);
+
+        return [
+            'data-callback-module' => 'TYPO3/CMS/Hugo/ContextMenuActions',
+            'data-preview-url' => 'http://' . $itemConfiguration['txHugoDomain'] . '/' . $rootLineUtility->getSlugifiedRootlinePath(),
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    protected function setHugoViewItemsConfiguration(): void
+    {
+        $domainUtility = GeneralUtility::makeInstance(DomainUtility::class);
+        $domains = $domainUtility->getHugoDomainsForPid($this->identifier);
+
+        foreach ($domains as $index => $domain) {
+            $this->itemsConfiguration['hugoView' . $index] = array_merge(
+                $this->hugoViewItemBaseConfiguration,
+                [
+                    'label' => $this->getHugoViewItemLabel($domain),
+                    'txHugoDomain' => $domain,
+                    'txHugoPageUid' => $this->identifier,
+                ]
+            );
+        }
+    }
+
+    /**
+     * @param $domain
+     *
+     * @return string
+     */
+    protected function getHugoViewItemLabel($domain): string
+    {
+        return sprintf(
+            GeneralUtility::makeInstance(LanguageService::class)->sL($this->hugoViewItemBaseConfiguration['label']),
+            strlen($domain) > 25 ? substr($domain, 0, 11) . '...' . substr($domain, -11) : $domain
+        );
+    }
+}

--- a/Classes/Utility/DomainUtility.php
+++ b/Classes/Utility/DomainUtility.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SourceBroker\Hugo\Utility;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class DomainUtility
+ * @package SourceBroker\Hugo\Utility
+ */
+class DomainUtility implements SingletonInterface
+{
+
+    /**
+     * @param int $pid
+     *
+     * @return string[]
+     */
+    public function getHugoDomainsForPid(int $pid): array
+    {
+        return array_filter(
+            (array)array_merge(
+                ...array_map(
+                    function($commaSeparatedHugoDomains) {
+                        return GeneralUtility::trimExplode(',', $commaSeparatedHugoDomains);
+                    },
+                    array_column($this->getDomainRecordsForRootLinePid($pid), 'tx_hugo_domains')
+                )
+            )
+        );
+    }
+
+    /**
+     * @param int $pid
+     *
+     * @return array
+     */
+    protected function getDomainRecordsForRootLinePid(int $pid): array
+    {
+        $rootLinePids = array_map(
+            function($rootLinePage) {
+                return (int)$rootLinePage['uid'];
+            },
+            GeneralUtility::makeInstance(RootlineUtility::class, $pid)->get()
+        );
+
+        if (empty($rootLinePids)) {
+            return [];
+        }
+
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_domain');
+
+        return $qb->select('*')
+            ->from('sys_domain')
+            ->where($qb->expr()->orX(
+                ...array_map(
+                    function($pid) use ($qb) {
+                        return $qb->expr()->eq('pid', $qb->createNamedParameter($pid, \PDO::PARAM_INT));
+                    },
+                    $rootLinePids
+                )
+            ))
+            ->execute()
+            ->fetchAll()
+        ;
+    }
+}

--- a/Configuration/TCA/Overrides/sys_domain.php
+++ b/Configuration/TCA/Overrides/sys_domain.php
@@ -1,0 +1,19 @@
+<?php
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
+    'sys_domain',
+    [
+        'tx_hugo_domains' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:hugo/Resources/Private/Language/locallang_db.xlf:sys_domain.tx_hugo_domains',
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+    ]
+);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+    'sys_domain',
+    '--div--;Hugo,tx_hugo_domains'
+);

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -12,6 +12,9 @@
             <trans-unit id="tt_content.tx_hugo_frontmatter">
                 <source>Hugo Front Matter</source>
             </trans-unit>
+            <trans-unit id="sys_domain.tx_hugo_domains">
+                <source>Hugo FE Domains (comma separated)</source>
+            </trans-unit>
 			<trans-unit id="task.export.title">
                 <source>Generating pages / content / media for all TYPO3 tree roots.</source>
             </trans-unit>
@@ -35,6 +38,9 @@
             </trans-unit>
 			<trans-unit id="task.exportContent.description">
                 <source></source>
+            </trans-unit>
+			<trans-unit id="context_menu.pageView.label">
+                <source>Show Hugo [%s]</source>
             </trans-unit>
         </body>
 	</file>

--- a/Resources/Public/JavaScript/ContextMenuActions.js
+++ b/Resources/Public/JavaScript/ContextMenuActions.js
@@ -1,0 +1,31 @@
+/**
+ * Module: TYPO3/CMS/Hugo/ContextMenuActions
+ *
+ * @exports TYPO3/CMS/Hugo/ContextMenuActions
+ */
+define(function () {
+    'use strict';
+
+    /**
+     * @exports TYPO3/CMS/Hugo/ContextMenuActions
+     */
+    var ContextMenuActions = {};
+
+    /**
+     * Say hello
+     *
+     * @param {string} table
+     * @param {int} uid of the page
+     */
+    ContextMenuActions.viewPage = function (table, uid) {
+        var $viewUrl = $(this).data('preview-url');
+        if ($viewUrl) {
+            var previewWin = window.open($viewUrl, 'newTYPO3frontendWindow');
+            previewWin.focus();
+        } else {
+            top.TYPO3.Notification.error('Error', 'Page preview URL could not be determined.', 5);
+        }
+    };
+
+    return ContextMenuActions;
+});

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,6 +12,7 @@ call_user_func(function () use ($_EXTKEY) {
 
     if (TYPO3_MODE === 'BE') {
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \SourceBroker\Hugo\Command\HugoCommandController::class;
+        $GLOBALS['TYPO3_CONF_VARS']['BE']['ContextMenu']['ItemProviders'][] = \SourceBroker\Hugo\ContextMenu\ItemProviders\PageView::class;
     }
 
     /** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,3 +1,7 @@
 CREATE TABLE tx_dce_domain_model_dce (
 	tx_hugo_typename varchar(255),
 );
+
+CREATE TABLE sys_domain (
+	tx_hugo_domains varchar(255),
+);


### PR DESCRIPTION
Extend sys_domain records by new field in which Hugo FE domains can be added (comma separated if multiple). For each of defined Hugo domain in specified rootLine there will be new button in page context-sensitive menu displayed to open selected page within Hugo.