### PR TITLE
[FEATURE] Implement support of content slide functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master
 2) [TASK] Remove support for legacy links.
 3) [BUGFIX] Bugfix for edge cases with link creation.
 4) [FEATURE] Add Hugo page view buttons into page context-sensitive menu.
+5) [FEATURE] Implement support of content slide functionality
 
 0.5.0
 ~~~~~

--- a/Classes/Domain/Repository/Typo3PageRepository.php
+++ b/Classes/Domain/Repository/Typo3PageRepository.php
@@ -58,10 +58,10 @@ class Typo3PageRepository
 
     /**
      * @param int $pageUid
-     * @param int $sysLangaugeUid
+     * @param int $sysLanguageUid
      * @return array
      */
-    public function getPageContentElements(int $pageUid, int $sysLangaugeUid = 0): array
+    public function getPageContentElements(int $pageUid, int $sysLanguageUid = 0): array
     {
         $queryBuilder = $this->getConnectionPool()
             ->getQueryBuilderForTable('tt_content');
@@ -74,7 +74,7 @@ class Typo3PageRepository
                     $queryBuilder->createNamedParameter($pageUid, \PDO::PARAM_INT)
                 ),
                 $queryBuilder->expr()->eq('sys_language_uid',
-                    $queryBuilder->createNamedParameter($sysLangaugeUid, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($sysLanguageUid, \PDO::PARAM_INT)
                 )
             )
             ->orderBy('sorting')

--- a/Classes/Service/BackendLayoutService.php
+++ b/Classes/Service/BackendLayoutService.php
@@ -1,0 +1,156 @@
+<?php
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+namespace SourceBroker\Hugo\Service;
+
+use SourceBroker\Hugo\Utility\RootlineUtility;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+use TYPO3\CMS\Core\Utility\StringUtility;
+
+/**
+ * Class Typo3UrlService
+ *
+ * @package SourceBroker\Hugo\Service
+ */
+class BackendLayoutService extends AbstractService implements SingletonInterface
+{
+    /**
+     * @var array
+     */
+    protected static $localIdentifierCache = [];
+
+    /**
+     * @var array
+     */
+    protected static $localCache = [];
+
+    /**
+     * @param int $pageUid
+     *
+     * @return string
+     */
+    public function getIdentifierByPage(int $pageUid): string
+    {
+        if (!isset(self::$localIdentifierCache[$pageUid])) {
+            $rootLine = ($this->objectManager->get(RootlineUtility::class, $pageUid))->get();
+
+            $identifier = '';
+
+            krsort($rootLine);
+            foreach ($rootLine as $key => $page) {
+                if ($pageUid == $page['uid'] && !empty($page['backend_layout'])) {
+                    $identifier = $page['backend_layout'];
+                    break;
+                }
+                if (!empty($page['backend_layout_next_level'])) {
+                    $identifier = $page['backend_layout_next_level'];
+                    break;
+                }
+            }
+
+            self::$localIdentifierCache[$pageUid] = $identifier;
+        }
+
+        return self::$localIdentifierCache[$pageUid];
+    }
+
+    /**
+     * @param int $pageUid
+     *
+     * @return array
+     */
+    public function getByPage(int $pageUid): array
+    {
+        if (!isset(self::$localCache[$pageUid])) {
+            $identifier = $this->getIdentifierByPage($pageUid);
+
+            if (!StringUtility::beginsWith($identifier, 'pagets__')) {
+                throw new \InvalidArgumentException('Only backend layouts from PageTSConfig are supported at the moment.', 1534620796);
+            }
+
+            $pageTsConfig = $this->objectManager->get(TypoScriptService::class)
+                ->convertTypoScriptArrayToPlainArray(BackendUtility::getPagesTSconfig($pageUid));
+
+            $pageTsConfigIdentifier = str_replace('pagets__', '', $identifier);
+
+            self::$localCache[$pageUid] = $pageTsConfig['mod']['web_layout']['BackendLayouts'][$pageTsConfigIdentifier] ?? [];
+        }
+
+        return self::$localCache[$pageUid];
+    }
+
+    /**
+     * @param int $pageUid
+     *
+     * @return array
+     */
+    public function getColPosesByPage(int $pageUid)
+    {
+        return array_unique(
+            array_map('intval', array_column($this->getColumnsByPage($pageUid), 'colPos'))
+        );
+    }
+
+    /**
+     * @param int $pageUid
+     * @param int $slideLevel
+     *
+     * @return array
+     */
+    public function getColPosesByPageAndSlideLevel(int $pageUid, int $slideLevel)
+    {
+        $colPoses = [];
+
+        foreach ($this->getColumnsByPage($pageUid) as $col) {
+            $hugoSlideLevel = (int)($col['txHugoSlide'] ?? 0);
+
+            if (isset($col['colPos']) && ($hugoSlideLevel === -1 || $hugoSlideLevel >= $slideLevel)) {
+                $colPoses[] = (int)$col['colPos'];
+            }
+        }
+
+        return $colPoses;
+    }
+
+    /**
+     * @param int $pageUid
+     *
+     * @return array
+     */
+    protected function getColumnsByPage(int $pageUid): array
+    {
+        $backendLayout = $this->getByPage($pageUid);
+        $rows = $backendLayout['config']['backend_layout']['rows'] ?? [];
+        $columns = [];
+
+        foreach ($rows as $row) {
+            $columns = array_merge($columns, ($row['columns'] ?? []));
+        }
+
+        return $columns;
+    }
+
+}

--- a/Classes/Utility/RootlineUtility.php
+++ b/Classes/Utility/RootlineUtility.php
@@ -126,7 +126,7 @@ class RootlineUtility
      *
      * @return array
      */
-    public function get()
+    public function get(): array
     {
         if (!isset(static::$localCache[$this->cacheIdentifier])) {
             $page = $this->getRecordArray($this->pageUid);


### PR DESCRIPTION
Content slide feature can be used by adding property `txHugoSlide` into backend layouts stored in pageTsConfig. Default value of this property is 0, what means there is not content inheritance at all. Sliding levels works in exact same way as in TYPO3 core. If value of `txHugoSlide` is set to 2, then content will be inherited at most from page 2 levels higher than the current one. Setting `txHugoSlide` to -1 means content will be inherited through all levels.

Example usage of content sliding for the template `Main`:
`mod.web_layout.BackendLayouts.Main.config.rows.1.columns.1.txHugoSlide = -1`