### PR TITLE
Implement basic version of database record link builder

### DIFF
--- a/Classes/Indexer/RecordIndexer.php
+++ b/Classes/Indexer/RecordIndexer.php
@@ -93,6 +93,7 @@ class RecordIndexer extends AbstractIndexer implements SingletonInterface
 
                         $this->parseFields($table, $record, $hugoConfig);
 
+                        // @todo make slug configurable and use same approach in \SourceBroker\Hugo\Typolink\DatabaseRecordLinkBuilder::build
                         $slug = $this->slugify($record['title']);
                         $document = $documentCollection->create();
                         $document->setStoreFilename($record['uid'] . '_' . ucfirst($slug))

--- a/Classes/Typolink/AbstractTypolinkBuilder.php
+++ b/Classes/Typolink/AbstractTypolinkBuilder.php
@@ -47,14 +47,16 @@ abstract class AbstractTypolinkBuilder extends \TYPO3\CMS\Frontend\Typolink\Abst
      * @param ContentObjectRenderer $contentObjectRenderer
      * @param Configurator $txHugoConfigurator
      * @param int $txHugoSysLanguageUid
+     *
+     * @throws \Exception
      */
     public function __construct(
         ContentObjectRenderer $contentObjectRenderer,
-        Configurator $txHugoConfigurator,
+        Configurator $txHugoConfigurator = null,
         int $txHugoSysLanguageUid = 0
     ) {
         parent::__construct($contentObjectRenderer);
-        $this->txHugoConfigurator = $txHugoConfigurator;
+        $this->txHugoConfigurator = $txHugoConfigurator ?? Configurator::getFirstRootsiteConfig();
         $this->txHugoSysLanguageUid = $txHugoSysLanguageUid;
     }
 

--- a/Classes/Typolink/DatabaseRecordLinkBuilder.php
+++ b/Classes/Typolink/DatabaseRecordLinkBuilder.php
@@ -16,9 +16,52 @@ namespace SourceBroker\Hugo\Typolink;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Cocur\Slugify\Slugify;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
 /**
  * Builds a TypoLink to a database record
  */
-class DatabaseRecordLinkBuilder extends \TYPO3\CMS\Frontend\Typolink\DatabaseRecordLinkBuilder
+class DatabaseRecordLinkBuilder extends AbstractTypolinkBuilder
 {
+    /**
+     * @inheritdoc
+     */
+    public function build(array &$linkDetails, string $linkText, string $target, array $conf): array
+    {
+        $linkHandlerConfiguration = $this->txHugoConfigurator->getOption('record.indexer.exporter.' . $linkDetails['identifier']);
+
+        $pageLinkBuilder = GeneralUtility::makeInstance(ObjectManager::class)->get(PageLinkBuilder::class, $this->txHugoConfigurator);
+
+        $pageLinkDetails = ['pageuid' => $linkHandlerConfiguration['pageUid']];
+
+        list($pageUri) = $pageLinkBuilder->build($pageLinkDetails, '', '', []);
+        $record = $this->getRecordByUid($linkHandlerConfiguration['table'], (int)$linkDetails['uid']);
+        // @todo make slug configurable and use same approach in \SourceBroker\Hugo\Indexer\RecordIndexer::getDocumentsForPage
+        $recordUri = $record['uid'] . '_' . (new Slugify())->slugify($record['title']) . '/';
+
+        return [
+            $pageUri . $recordUri,
+            $linkText,
+            $target
+        ];
+    }
+
+    /**
+     * @param $table
+     * @param $recordUid
+     *
+     * @return int
+     */
+    protected function getRecordByUid($table, $recordUid)
+    {
+        return ($qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table))
+            ->select('*')
+            ->from($table)
+            ->where($qb->expr()->eq('uid', $qb->createNamedParameter($recordUid, \PDO::PARAM_INT)))
+            ->execute()
+            ->fetch();
+    }
 }


### PR DESCRIPTION
1) Implement basic version of database record link builder.
2) Make it possible to initialize Hugo TypoLinkBuilder in the same way as base TYPO3 TypoLinkBuilder is initialized. This allows to use hugo DatabaseRecordLinkBuilder by third party extensions.